### PR TITLE
[ADD] Card Flipping 애니메이션 구현

### DIFF
--- a/AppleStop/AppleStop/Screens/Home/Component/LocationInformationView.swift
+++ b/AppleStop/AppleStop/Screens/Home/Component/LocationInformationView.swift
@@ -14,7 +14,6 @@ struct LocationInformationView: View {
     var location = "연일읍"
     var recyclingDay = "음식물쓰레기 배출일"
     
-    
     var body: some View {
         ZStack{
             Rectangle()
@@ -25,9 +24,13 @@ struct LocationInformationView: View {
                 .shadow(color: .black.opacity(0.04), radius: 2, x: 0, y: 1)
                 .shadow(color: .black.opacity(0.18), radius: 2, x: 0, y: 1)
             HStack{
-                Text("오늘은 '") + Text(location) + Text("'의 ") + Text(recyclingDay).foregroundColor(.mainGreen) + Text("입니다")
+                Text("오늘은 '\(location)'의 \(recyclingDayColor)입니다.")
             }.font(Font.headline.weight(.medium))
         }
+    }
+
+    var recyclingDayColor: Text {
+        Text(recyclingDay).foregroundColor(.mainGreen)
     }
 }
 

--- a/AppleStop/AppleStop/Screens/Home/View/HomeView.swift
+++ b/AppleStop/AppleStop/Screens/Home/View/HomeView.swift
@@ -15,8 +15,6 @@ struct HomeView: View {
     @State var frontDegree = 0.0
     @State var isFlipped = false
     
-    let width : CGFloat = 200
-    let height : CGFloat = 250
     let durationAndDelay : CGFloat = 0.2
     
     // MARK: Flip Card Function

--- a/AppleStop/AppleStop/Screens/Home/View/HomeView.swift
+++ b/AppleStop/AppleStop/Screens/Home/View/HomeView.swift
@@ -21,24 +21,24 @@ struct HomeView: View {
     
     // MARK: Flip Card Function
     
-        func flipCard () {
-            isFlipped = !isFlipped
-            if isFlipped {
-                withAnimation(.linear(duration: durationAndDelay)) {
-                    backDegree = 90
-                }
-                withAnimation(.linear(duration: durationAndDelay).delay(durationAndDelay)){
-                    frontDegree = 0
-                }
-            } else {
-                withAnimation(.linear(duration: durationAndDelay)) {
-                    frontDegree = -90
-                }
-                withAnimation(.linear(duration: durationAndDelay).delay(durationAndDelay)){
-                    backDegree = 0
-                }
+    func flipCard () {
+        isFlipped = !isFlipped
+        if isFlipped {
+            withAnimation(.linear(duration: durationAndDelay)) {
+                backDegree = 90
+            }
+            withAnimation(.linear(duration: durationAndDelay).delay(durationAndDelay)){
+                frontDegree = 0
+            }
+        } else {
+            withAnimation(.linear(duration: durationAndDelay)) {
+                frontDegree = -90
+            }
+            withAnimation(.linear(duration: durationAndDelay).delay(durationAndDelay)){
+                backDegree = 0
             }
         }
+    }
     
     var body: some View {
         ZStack {
@@ -52,14 +52,22 @@ struct HomeView: View {
                 Spacer()
                     .frame(height: 22)
                 
-                ZStack {
+                ZStack(alignment: .top) {
                     CharacterCardFrontView(degree: $frontDegree)
                         .padding(.horizontal, 24)
                     CharacterCardBackView(degree: $backDegree)
                         .padding(.horizontal, 24)
-                }
-                .onTapGesture {
-                    flipCard ()
+                    HStack {
+                        Rectangle().opacity(0)
+                            .frame(width: 80, height: 60)
+                            .contentShape(Rectangle())
+                        Spacer().frame(width: 180)
+                        Rectangle().opacity(0)
+                            .frame(width: 80, height: 60)
+                            .contentShape(Rectangle()).onTapGesture {
+                                flipCard ()
+                            }
+                    }.frame(width: 342)
                 }
                 
                 Spacer()
@@ -77,6 +85,7 @@ struct HomeView: View {
             }
         }
     }
+    
 }
 
 struct HomeView_Previews: PreviewProvider {


### PR DESCRIPTION
## 🟣 관련 이슈

- #6 #12 

## 🟣 구현/변경 사항 및 이유

홈 화면 UI 구현중에 card flipping 애니메이션이 빠졌네요,, 호다닥 추가합니다

## 🟣 PR Point

stack들이 지저분하게 쌓여있습니다...
좀 더 깔끔하게 정리할 수 있는 방법이 있을까요?

## 🟣 참고 사항

우측 상단 flip 아이콘을 누르면 캐릭터 뒷면으로 전환

https://user-images.githubusercontent.com/51108729/162693031-34b8e09d-0805-42bd-85bd-053c84eb942b.mov


