### PR TITLE
[ADD] 분리수거 실천도, 레벨 차트 애니메이션 추가

### DIFF
--- a/AppleStop/AppleStop/Screens/Home/Component/LevelInformationView.swift
+++ b/AppleStop/AppleStop/Screens/Home/Component/LevelInformationView.swift
@@ -63,7 +63,7 @@ struct DonutChartView: View {
                 .rotationEffect(.degrees(-90))
             Text("LV.\(level)").font(.system(size: 14)).fontWeight(.semibold)
         }.animation(.spring(response: 2), value: progress).onAppear{
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     self.progress = 0.72
                 }
         }

--- a/AppleStop/AppleStop/Screens/Home/Component/WasteInformationView.swift
+++ b/AppleStop/AppleStop/Screens/Home/Component/WasteInformationView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 
 struct WasteInformationView: View {
     
-    @State var weeklyWasteData: [CGFloat] = [10, 20, 30, 30, 40, 50, 0]
+    // MARK: - properties
+    
+    @State var weeklyWasteData: [CGFloat] = [70, 50, 60, 30, 40, 30, 0]
+    
+    var weeklyGoal: CGFloat = 50.0
     
     var body: some View {
         ZStack{
@@ -25,13 +29,13 @@ struct WasteInformationView: View {
                 Text("분리수거 실천도").fontWeight(.medium).font(.system(size: 14))
                 
                 HStack(spacing: 10){
-                    BarChartView(value: weeklyWasteData[0], day: "M")
-                    BarChartView(value: weeklyWasteData[1], day: "T")
-                    BarChartView(value: weeklyWasteData[2], day: "W")
-                    BarChartView(value: weeklyWasteData[3], day: "T")
-                    BarChartView(value: weeklyWasteData[4], day: "F")
-                    BarChartView(value: weeklyWasteData[5], day: "S")
-                    BarChartView(value: weeklyWasteData[6], day: "S")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[0], day: "M")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[1], day: "T")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[2], day: "W")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[3], day: "T")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[4], day: "F")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[5], day: "S")
+                    BarChartView(goal: weeklyGoal, value: weeklyWasteData[6], day: "S")
                 }.padding(.top, 6)
                 
                 
@@ -43,15 +47,34 @@ struct WasteInformationView: View {
 
 struct BarChartView: View {
     
-    var value: CGFloat
+    var goal: CGFloat
+    @ State var value: CGFloat
     var day: String
+    
+    @ State var startvalue = 0.0
+    
+    var animatableData: Double {
+            get {
+                self.startvalue
+            }
+            set {
+                self.startvalue = newValue
+            }
+        }
     
     var body: some View {
         VStack{
             ZStack(alignment: .bottom){
                 Capsule().frame(width: 7, height: 60).foregroundColor(.chartGrey)
-                Capsule().frame(width: 7, height: value).foregroundColor(.mainGreen)
-                
+                if startvalue>=goal {
+                    Capsule().frame(width: 7, height: 60).foregroundColor(.mainGreen)
+                } else {
+                    Capsule().frame(width: 7, height: startvalue/goal*60).foregroundColor(.iconGrey)
+                }
+            }.animation(.spring(response: 2), value: startvalue).onAppear{
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        self.startvalue = value
+                    }
             }
             Text(day).padding(.top, 4).font(.system(size: 10))
         }

--- a/AppleStop/AppleStop/Screens/Home/View/WastePopupView.swift
+++ b/AppleStop/AppleStop/Screens/Home/View/WastePopupView.swift
@@ -13,10 +13,11 @@ struct WastePopupView: View {
     
     @Binding var showState: Bool
     
-    @State var wasteDayData: [CGFloat] = [10, 20, 30, 30, 40, 50, 0]
+    @State var wasteDayData: [CGFloat] = [70, 50, 60, 30, 40, 30, 0]
     @State var wasteTypeData: [CGFloat] = [5,12,3,1,5,8]
     
-    var wasteGoal = 10
+    var weeklyGoal: CGFloat = 50.0
+    var wasteGoal: CGFloat = 10.0
     
     var body: some View {
         ZStack(alignment: .center){
@@ -43,23 +44,23 @@ struct WastePopupView: View {
                    Text("나의 분리수거 실천도").fontWeight(.medium).font(.system(size: 18))
                    
                     HStack(spacing: 26){
-                        BarChartView(value: wasteDayData[0], day: "M")
-                        BarChartView(value: wasteDayData[1], day: "T")
-                        BarChartView(value: wasteDayData[2], day: "W")
-                        BarChartView(value: wasteDayData[3], day: "T")
-                        BarChartView(value: wasteDayData[4], day: "F")
-                        BarChartView(value: wasteDayData[5], day: "S")
-                        BarChartView(value: wasteDayData[6], day: "S")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[0], day: "M")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[1], day: "T")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[2], day: "W")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[3], day: "T")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[4], day: "F")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[5], day: "S")
+                        BarChartView(goal: weeklyGoal, value: wasteDayData[6], day: "S")
                     }.padding(.top, 14)
                     
                     
                     VStack(spacing: 18){
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[0], wasteType: "glass")
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[1], wasteType: "plastic")
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[2], wasteType: "vinyl")
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[3], wasteType: "paper")
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[4], wasteType: "rubber")
-                        HorizontalBarChartView(goal: CGFloat(wasteGoal), value: wasteTypeData[5], wasteType: "can")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[0], wasteType: "glass")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[1], wasteType: "plastic")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[2], wasteType: "vinyl")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[3], wasteType: "paper")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[4], wasteType: "rubber")
+                        HorizontalBarChartView(goal: wasteGoal, value: wasteTypeData[5], wasteType: "can")
                     }.padding(.top, 20)
                 }
                 
@@ -75,29 +76,36 @@ struct HorizontalBarChartView: View {
     var goal: CGFloat
     var value: CGFloat
     var wasteType: String
-    
+    @State var startvalue = 0.0
     
     var body: some View {
-        HStack(alignment: .center){
-            Image(wasteType)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 22, height: 30)
-            
-            ZStack(alignment: .leading){
-                Capsule().frame(width: 205, height: 6).foregroundColor(.chartGrey)
-                if value>goal {
-                    Capsule().frame(width: 205, height: 6).foregroundColor(.mainGreen)
-                } else {
-                    Capsule().frame(width: value/goal*205, height: 6).foregroundColor(.mainGreen)
-                }
+        ZStack {
+            HStack(alignment: .center){
+                Image(wasteType)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 22, height: 30)
                 
-            }.padding(.horizontal, 10)
-            
-            Text("\(Int(value/goal*100))%")
-                .font(.system(size: 14))
-                .frame(width: 40)
+                ZStack(alignment: .leading){
+                    Capsule().frame(width: 205, height: 6).foregroundColor(.chartGrey)
+                    if startvalue>=goal {
+                        Capsule().frame(width: 205, height: 6).foregroundColor(.mainGreen)
+                    } else {
+                        Capsule().frame(width: startvalue/goal*205, height: 6).foregroundColor(.iconGrey)
+                    }
+                    
+                }.padding(.horizontal, 10)
+                
+                Text("\(Int(value/goal*100))%")
+                    .font(.system(size: 14))
+                    .frame(width: 40)
+            }
+        }.animation(.spring(response: 2), value: startvalue).onAppear{
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self.startvalue = value
+                }
         }
+        
     }
 }
 


### PR DESCRIPTION
## 🟣 관련 이슈

- #21 

## 🟣 구현/변경 사항 및 이유

앱이 단조로운 것 같아 홈화면 그래프에 애니메이션을 추가했습니다.

## 🟣 PR Point

실천을 모두 완수한 날짜, 분리수거 항목은 초록색으로 표시하고 완수하지 못한 날짜, 항목은 회색으로 처리했습니다.

## 🟣 참고 사항


https://user-images.githubusercontent.com/51108729/163202878-95ecbacc-4f06-4233-8b1e-5c1a0146a36b.mov



